### PR TITLE
chore: increase restore snapshot timeout to 180 mins

### DIFF
--- a/src/sanitizer/rds.py
+++ b/src/sanitizer/rds.py
@@ -92,6 +92,7 @@ def restore_snapshot(snapshot: DBClusterSnapshotTypeDef) -> DBClusterTypeDef:
         {"DBClusterIdentifier": restored_cluster["DBClusterIdentifier"]},
         "Restoring to temporary cluster",
         "Timed out when restoring cluster",
+        180, 
     )
 
     # Disable AutoMinorVersionUpgrade and set PreferredBackupWindow


### PR DESCRIPTION
Saascore has recently had relatively frequent timeouts on the snapshot restore path, causing some increase in costs due to the leftover clusters.

This PR increases the restore snapshot timeout to 180 mins, from the 60 min default.
